### PR TITLE
Added support for recognizing comment lines that start with a #

### DIFF
--- a/syntaxes/arm.json
+++ b/syntaxes/arm.json
@@ -13,6 +13,10 @@
       "name": "comment.arm"
     },
     {
+      "match": "^\\s*#.*$",
+      "name": "comment.arm"
+    },
+    {
       "name": "comment.arm",
       "begin": "\\/\\*",
       "beginCaptures": {


### PR DESCRIPTION
I am not sure if this is the conventional way to write ARM comments, but I noticed that lines that start with a # would also work as a comment (I learned this from my TA's code); so I decided to add this to the syntax highlighting so that those lines can be recognized as comments. Please let me know if this helps or if there is anything I should change!