### PR TITLE
Add back autoclosing for brackets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/arm.configuration.json
+++ b/arm.configuration.json
@@ -12,6 +12,8 @@
 		["(", ")"]
 	],
 	"autoClosingPairs": [
+		{ "open": "(", "close": ")" },
+		{ "open": "[", "close": "]" },
 		{ "open": "'", "close": "'", "notIn": ["string"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string"] },
 		{ "open": "/*", "close": " */", "notIn": ["string"] }


### PR DESCRIPTION
Sorry, it seems my last PR disabled the default autoclosing for brackets; this should add it back. I also added a launch configuration to easily launch a vscode instance for testing.