### PR TITLE
Directives highlighting

### DIFF
--- a/syntaxes/arm.tmlanguage.json
+++ b/syntaxes/arm.tmlanguage.json
@@ -125,7 +125,7 @@
     },
     {
       "name": "keyword.control.directive.arm",
-      "match": "\\.(?i)(globl|global|macro|endm|purgem|section|text|data|bss|arm|align|balign|irp|rept|endr|(un)?req|error|short|(end)?func|hidden|type|fpu|arch|code|altmacro|object_arch|word|int|string|thumb|set|pragma|undef|line|get)(?-i)\\b"
+      "match": "\\.(?i)(globl|global|extern|weak|macro|endm|purgem|section|text|data|bss|arm|align|balign|irp|rept|endr|(un)?req|error|short|(end)?func|hidden|type|fpu|arch|code|altmacro|object_arch|word|int|string|thumb|set|pragma|undef|line|get)(?-i)\\b"
     },
     {
       "match": "\\b\\=",

--- a/syntaxes/arm.tmlanguage.json
+++ b/syntaxes/arm.tmlanguage.json
@@ -125,7 +125,7 @@
     },
     {
       "name": "keyword.control.directive.arm",
-      "match": "\\.(?i)(globl|global|extern|weak|macro|endm|purgem|section|text|data|bss|arm|align|balign|irp|rept|endr|(un)?req|error|short|(end)?func|hidden|type|fpu|arch|code|altmacro|object_arch|word|int|string|thumb|set|pragma|undef|line|get)(?-i)\\b"
+      "match": "\\.(?i)(globl|global|extern|weak|macro|endm|purgem|section|text|data|bss|arm|align|balign|irp|rept|endr|(un)?req|error|short|(end)?func|hidden|type|cpu|fpu|arch|code|syntax|altmacro|object_arch|word|int|string|thumb|thumb_set|set|pragma|undef|line|get)(?-i)\\b"
     },
     {
       "match": "\\b\\=",


### PR DESCRIPTION
Resolves #20 

Add syntax highlighting to:
- `.extern`
- `.weak`
- `.cpu`
- `.syntax`
- `.thumb_set`