### PR TITLE
Add support for common C-like escape sequences

### DIFF
--- a/syntaxes/arm.tmlanguage.json
+++ b/syntaxes/arm.tmlanguage.json
@@ -315,7 +315,13 @@
         {
           "name": "string.quoted.arm",
           "begin": "\"",
-          "end": "\""
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.backslash",
+              "match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3][0-7]{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )"
+            }
+          ]
         },
         {
           "match": "\\'\\S\\'",

--- a/test.s
+++ b/test.s
@@ -6,8 +6,9 @@
 @	Description - Example ARM Source File
 
 strings:
-string_a: 	defw	"Awaiting input"
+string_a: 	defw	"Awaiting input\n"
 string_b:	defb    'a', 'b', 'c', 'd'
+string_c:	defw	"this: '\"' is a quote"
 
 branches:
 		b		start			@ With comment!


### PR DESCRIPTION
Fixes #33 

Regex is taken from the VSCode builtin C definitions:
https://github.com/Microsoft/vscode/blob/main/extensions/cpp/syntaxes/c.tmLanguage.json#L3113

Before:
![Screen Shot 2022-05-28 at 8 38 05 AM](https://user-images.githubusercontent.com/11131775/170826057-6b31cb61-a303-4020-975f-87f734a9e605.png)

After:
![Screen Shot 2022-05-28 at 8 43 20 AM](https://user-images.githubusercontent.com/11131775/170826059-28e6aeba-a829-484c-92df-841fb3ae9ba4.png)

